### PR TITLE
Fix default pagination limit

### DIFF
--- a/framework/bigcommerce/api/operations/get-all-product-paths.ts
+++ b/framework/bigcommerce/api/operations/get-all-product-paths.ts
@@ -9,7 +9,7 @@ import filterEdges from '../utils/filter-edges'
 import { BigcommerceConfig, Provider } from '..'
 
 export const getAllProductPathsQuery = /* GraphQL */ `
-  query getAllProductPaths($first: Int = 100) {
+  query getAllProductPaths($first: Int = 50) {
     site {
       products(first: $first) {
         edges {


### PR DESCRIPTION
Max allowed limit on `first` argument for products node is `50`. 

The change will be enforced by BigCommerce in the near future and this query will return the next error:
```
"Argument 'first' cannot exceed 50"
```